### PR TITLE
Fixed C++14 required compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,3 +14,4 @@ Imports:
     sp
 LinkingTo: Rcpp, BH
 RoxygenNote: 5.0.1
+SystemRequirements: C++14


### PR DESCRIPTION
Without specifying the system requirements, the package doesn't compile